### PR TITLE
Add phpstan 0.10 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@
 language: php
 
 php:
-  - "7.0"
   - "7.1"
+  - "7.2"
   - nightly
 
 env:

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "myclabs/php-enum": "^1.2",
-        "phpstan/phpstan": "^0.6 || ^0.7 || ^0.8 || ^0.9"
+        "phpstan/phpstan": "^0.10"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0"

--- a/src/Reflection/EnumMethodReflection.php
+++ b/src/Reflection/EnumMethodReflection.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace Timeweb\PHPStan\Reflection;
 
+use PHPStan\Reflection\ClassMemberReflection;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
-use PHPStan\Type\ObjectType;
-use PHPStan\Type\Type;
 
 class EnumMethodReflection implements MethodReflection
 {
@@ -32,21 +31,6 @@ class EnumMethodReflection implements MethodReflection
         return $this->name;
     }
 
-    public function getParameters(): array
-    {
-        return [];
-    }
-
-    public function isVariadic(): bool
-    {
-        return false;
-    }
-
-    public function getReturnType(): Type
-    {
-        return new ObjectType($this->classReflection->getName(), false);
-    }
-
     public function getDeclaringClass(): ClassReflection
     {
         return $this->classReflection;
@@ -67,8 +51,13 @@ class EnumMethodReflection implements MethodReflection
         return true;
     }
 
-    public function getPrototype(): MethodReflection
+    public function getPrototype(): ClassMemberReflection
     {
         return $this;
+    }
+
+    public function getVariants(): array
+    {
+        return [];
     }
 }


### PR DESCRIPTION
phpstan 0.10 introduce internal change in `PHPStan\Reflection\MethodReflection`.

So, the `Timeweb\PHPStan\Reflection\EnumMethodReflection` class need to be updated. This imply that the extension is not compatible anymore with `phpstan < 0.10` and require `php >= 7.1` (phpstan 0.10 requirement).