### PR TITLE
Add AlwaysUsedClassConstantsExtension rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.phpunit.result.cache
 /composer.lock
 /phpunit.xml
 /vendor/

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": "~7.1|^8.0",
         "myclabs/php-enum": "^1.2",
-        "phpstan/phpstan": "^0.10|^0.11|^0.12.34"
+        "phpstan/phpstan": "^0.12.84"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0|^9.0"

--- a/extension.neon
+++ b/extension.neon
@@ -2,3 +2,6 @@ services:
   - class: Timeweb\PHPStan\Reflection\EnumMethodsClassReflectionExtension
     tags:
       - phpstan.broker.methodsClassReflectionExtension
+  - class: Timeweb\PHPStan\Rule\EnumAlwaysUsedConstants
+    tags:
+      - phpstan.constants.alwaysUsedClassConstantsExtension

--- a/src/Rule/EnumAlwaysUsedConstantsExtension.php
+++ b/src/Rule/EnumAlwaysUsedConstantsExtension.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Timeweb\PHPStan\Rule;
+
+use MyCLabs\Enum\Enum;
+use PHPStan\Reflection\ConstantReflection;
+use PHPStan\Rules\Constants\AlwaysUsedClassConstantsExtension;
+
+class EnumAlwaysUsedConstantsExtension implements AlwaysUsedClassConstantsExtension
+{
+    public function isAlwaysUsed(ConstantReflection $constant): bool
+    {
+        return $constant->getDeclaringClass()->isSubclassOf(Enum::class);
+    }
+}

--- a/tests/Rule/EnumAlwaysUsedConstantsExtensionTest.php
+++ b/tests/Rule/EnumAlwaysUsedConstantsExtensionTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Timeweb\Tests\PHPStan\Rule;
+
+use PHPStan\Testing\TestCase;
+use Timeweb\PHPStan\Rule\EnumAlwaysUsedConstantsExtension;
+use Timeweb\Tests\PHPStan\Fixture\EnumFixture;
+
+/**
+ * @coversDefaultClass \Timeweb\PHPStan\Rule\EnumAlwaysUsedConstantsExtension
+ */
+class EnumAlwaysUsedConstantsExtensionTest extends TestCase
+{
+    /**
+     * @var \PHPStan\Broker\Broker
+     */
+    protected $broker;
+
+    /**
+     * @var EnumAlwaysUsedConstantsExtension
+     */
+    protected $constantsExtension;
+
+    public function setUp(): void
+    {
+        $this->broker = $this->createBroker();
+        $this->constantsExtension = new EnumAlwaysUsedConstantsExtension();
+    }
+
+    /**
+     * @covers ::isAlwaysUsed
+     * @dataProvider enumFixtureProperties
+     */
+    public function testEnumConstantsAreConsideredAsAlwaysUsed(string $constantName): void
+    {
+        $classReflection = $this->broker->getClass(EnumFixture::class);
+        $constantReflection = $classReflection->getConstant($constantName);
+
+        $this->assertTrue($this->constantsExtension->isAlwaysUsed($constantReflection));
+
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function enumFixtureProperties(): array
+    {
+        return [
+            ['MEMBER'],
+            ['PUBLIC_CONST'],
+            ['PRIVATE_CONST'],
+        ];
+    }
+}


### PR DESCRIPTION
Like I explain in [that issue](https://github.com/phpstan/phpstan/issues/4859), when using PHPStan [_bleeding edge_](https://phpstan.org/blog/what-is-bleeding-edge) mode with private `Enum` constant, we need to custom ignore errors rules because PHPStan consider those constants as unused.

To avoid that, the [last release](https://github.com/phpstan/phpstan/releases/tag/0.12.84) had a `AlwaysUsedClassConstantsExtension` to deal with this case.

So this PR implement this system to allow using _bleeding edge_ with private `Enum` constants without adding custom rules.