### PR TITLE
Use correct FQCN for class EnumAlwaysUsedConstantsExtension in extension.neon

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -2,6 +2,6 @@ services:
   - class: Timeweb\PHPStan\Reflection\EnumMethodsClassReflectionExtension
     tags:
       - phpstan.broker.methodsClassReflectionExtension
-  - class: Timeweb\PHPStan\Rule\EnumAlwaysUsedConstants
+  - class: Timeweb\PHPStan\Rule\EnumAlwaysUsedConstantsExtension
     tags:
       - phpstan.constants.alwaysUsedClassConstantsExtension


### PR DESCRIPTION
Fixes https://github.com/timeweb/phpstan-enum/issues/20